### PR TITLE
feat: 펀딩 상세 페이지 구현

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -8,6 +8,7 @@ import InvitationCreateProcess2 from "./pages/invitation/InvitationCreateProcess
 import ProductList from "./pages/product/ProductList";
 import ProductDetail from "./pages/product/ProductDetail";
 import FundingParticipation from './pages/funding/FundingParticipation';
+import FundingList from './pages/funding/FundingList';
 
 function Router() {
   return (
@@ -27,6 +28,7 @@ function Router() {
       <Route path="/products" element={<ProductList />} />
       <Route path="/items/:productOptionsId" element={<ProductDetail />} />
       <Route path="/funding/create/:productOptionsId" element={<FundingParticipation />} />
+      <Route path="/couples/:coupleId/fundings" element={<FundingList />} />
     </Routes>
   );
 }

--- a/src/Router.js
+++ b/src/Router.js
@@ -9,6 +9,7 @@ import ProductList from "./pages/product/ProductList";
 import ProductDetail from "./pages/product/ProductDetail";
 import FundingCreate from './pages/funding/FundingCreate';
 import FundingList from './pages/funding/FundingList';
+import FundingDetail from './pages/funding/FundingDetail';
 
 function Router() {
   return (
@@ -29,6 +30,7 @@ function Router() {
       <Route path="/items/:productOptionsId" element={<ProductDetail />} />
       <Route path="/funding/create/:productOptionsId" element={<FundingCreate />} />
       <Route path="/couples/:coupleId/fundings" element={<FundingList />} />
+      <Route path="/fundings/:fundingId" element={<FundingDetail />} />
     </Routes>
   );
 }

--- a/src/Router.js
+++ b/src/Router.js
@@ -7,7 +7,7 @@ import InvitationCreateProcess1 from "./pages/invitation/InvitationCreateProcess
 import InvitationCreateProcess2 from "./pages/invitation/InvitationCreateProcess2";
 import ProductList from "./pages/product/ProductList";
 import ProductDetail from "./pages/product/ProductDetail";
-import FundingParticipation from './pages/funding/FundingParticipation';
+import FundingCreate from './pages/funding/FundingCreate';
 import FundingList from './pages/funding/FundingList';
 
 function Router() {
@@ -27,7 +27,7 @@ function Router() {
       />
       <Route path="/products" element={<ProductList />} />
       <Route path="/items/:productOptionsId" element={<ProductDetail />} />
-      <Route path="/funding/create/:productOptionsId" element={<FundingParticipation />} />
+      <Route path="/funding/create/:productOptionsId" element={<FundingCreate />} />
       <Route path="/couples/:coupleId/fundings" element={<FundingList />} />
     </Routes>
   );

--- a/src/components/funding/FundingCardComponent.js
+++ b/src/components/funding/FundingCardComponent.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const FundingCardWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 13px;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    margin-bottom: 16px;
+`;
+
+const FundingImageWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 16px;
+`;
+
+const FundingImage = styled.img`
+    width: 100px;
+    height: 100px;
+    object-fit: cover;
+    border-radius: 8px;
+    margin-right: 16px;
+`;
+
+const FundingDetails = styled.div`
+    flex: 1;
+`;
+
+const FundingTitle = styled.div`
+    font-size: 16px;
+    font-weight: bold;
+    font-family: "Pretendard";
+    margin-bottom: 10px;
+`;
+
+const FundingInfo = styled.div`
+    font-size: 12px;
+    font-family: "Pretendard";
+    color: #666;
+`;
+
+const FundingProgressContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    margin-bottom: 8px;
+`;
+
+const ProgressBar = styled.div`
+    width: 100%;
+    height: 10px;
+    background-color: #ddd;
+    border-radius: 5px;
+    overflow: hidden;
+    margin-top: 4px;
+`;
+
+const Progress = styled.div`
+    width: ${props => props.progress}%;
+    height: 100%;
+    background-color: #4c3073;
+`;
+
+const ProgressInfo = styled.div`
+    font-size: 12px;
+    font-family: "Pretendard";
+    color: #666;
+`;
+
+
+const FundingCardComponent = ({ funding }) => {
+    const progress = (funding.currentAmount / funding.targetAmount) * 100;
+
+    return (
+        <FundingCardWrapper>
+            <FundingImageWrapper>
+                <FundingImage src={`https://lovecloud-storage.s3.ap-northeast-2.amazonaws.com/images/${funding.productOptions.mainImages[0].imageName}`} alt={funding.title} />
+                <FundingDetails>
+                    <FundingTitle>{funding.title}</FundingTitle>
+                    <FundingInfo>{funding.participantCount}명 참여</FundingInfo>
+                    <FundingInfo>마감 기한 {new Date(funding.endDate).toLocaleDateString()}</FundingInfo>
+                </FundingDetails>
+            </FundingImageWrapper>
+            <FundingProgressContainer>
+                <ProgressInfo>펀딩 진행률 {progress.toFixed(2)}%</ProgressInfo>
+                <ProgressInfo>{funding.currentAmount.toLocaleString()}원 / {funding.targetAmount.toLocaleString()}원</ProgressInfo>
+            </FundingProgressContainer>
+            <ProgressBar>
+                <Progress progress={progress} />
+            </ProgressBar>
+        </FundingCardWrapper>
+    );
+};
+
+export default FundingCardComponent;

--- a/src/components/funding/GuestFundingComponent.js
+++ b/src/components/funding/GuestFundingComponent.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// 텍스트
+
+const FundingMessageText = styled.div`
+    font-family: "Pretendard";
+    font-size: 14px;
+    color: #767676;
+`;
+
+const GuestNameText = styled.div`
+    font-family: "Pretendard";
+    font-weight: bold;
+    font-size: 14px;
+    color: #767676
+`;
+
+const GuestFundingAmountText = styled.div`
+    font-family: "Pretendard";
+    font-size: 14px;
+    color: #767676;
+`;
+
+const GuestMessageText = styled.div`
+    font-family: "Pretendard";
+    font-size: 14px;
+    color: #FFFFFF;
+`;
+
+// 펀딩 메시지
+
+const FundingMessageContainer = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 20px;
+`;
+
+const FundingMessage = styled.div`
+    background-color: #D9D9D9;
+    padding: 20px;
+    border-radius: 15px 15px 0 15px;
+    font-family: "Pretendard";
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    width: 80%;
+`;
+
+// 게스트 메시지
+
+const GuestFundingWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 20px;
+`;
+
+const GuestInfoContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 5px;
+    width: 90%;
+`;
+
+const GuestMessage = styled.div`
+    background-color: #B49AD9;
+    padding: 20px;
+    border-radius: 15px 15px 15px 0;
+    margin-bottom: 20px;
+    font-family: "Pretendard";
+    box-shadow: 0 4px 8px rgba(180, 154, 217, 0.8);
+    width: 80%;
+    align-self: flex-start;
+    position: relative;
+`;
+
+const GuestFundingComponent = ({ message, guestFunding }) => {
+    return (
+        <div>
+            <FundingMessageContainer>
+                <FundingMessage>
+                    <FundingMessageText>{message}</FundingMessageText>
+                </FundingMessage>
+            </FundingMessageContainer>
+            <GuestFundingWrapper>
+                {guestFunding.map((guest) => (
+                    <div key={guest.guestFundingId}>
+                        <GuestInfoContainer>
+                            <GuestNameText>{guest.name}</GuestNameText>
+                            <GuestFundingAmountText>{guest.fundingAmount}원</GuestFundingAmountText>
+                        </GuestInfoContainer>
+                        <GuestMessage>
+                            <GuestMessageText>{guest.message}</GuestMessageText>
+                        </GuestMessage>
+                    </div>
+                ))}
+            </GuestFundingWrapper>
+        </div>
+    );
+};
+
+export default GuestFundingComponent;

--- a/src/pages/funding/FundingCreate.js
+++ b/src/pages/funding/FundingCreate.js
@@ -60,7 +60,7 @@ const ProductPrice = styled.div`
     color: #666;
 `;
 
-const FundingParticipation = () => {
+const FundingCreate = () => {
     const navigate = useNavigate();
     const { productOptionsId } = useParams();
     const [product, setProduct] = useState(null);
@@ -145,4 +145,4 @@ const FundingParticipation = () => {
     );
 };
 
-export default FundingParticipation;
+export default FundingCreate;

--- a/src/pages/funding/FundingDetail.js
+++ b/src/pages/funding/FundingDetail.js
@@ -6,8 +6,10 @@ import AppContainer from "../../components/AppContainer";
 import NavigationBar from "../../components/Nav/NavigationBar";
 import ContentContainer from "../../components/ContentContainer";
 import BackButtonIcon from '../../assets/images/back-button.png';
+import PurpleButton from "../../components/button/PurpleButton";
 import { TopContainer, BackButton, CenterTitle } from '../../components/Header/Header';
 import FundingCardComponent from '../../components/funding/FundingCardComponent';
+import GuestFundingComponent from '../../components/funding/GuestFundingComponent';
 
 const FundingDetail = () => {
     const navigate = useNavigate();
@@ -37,6 +39,23 @@ const FundingDetail = () => {
         }
     };
 
+    const guestFunding = [
+        {
+            "guestFundingId": 1,
+            "name": "게스트일",
+            "fundingAmount": 1000,
+            "message": "결혼 축하한다. 행복하게 잘 살렴.",
+            "paidAt": "2024-06-07T02:52:44"
+        },
+        {
+            "guestFundingId": 2,
+            "name": "게스트이",
+            "fundingAmount": 2000,
+            "message": "결혼 축2",
+            "paidAt": "2024-06-07T02:52:54"
+        }
+    ];
+
     return (
         <AppContainer>
             <NavigationBar />
@@ -46,6 +65,10 @@ const FundingDetail = () => {
                     <CenterTitle>펀딩 상세</CenterTitle>
                 </TopContainer>
                 <FundingCardComponent funding={funding} />
+                <GuestFundingComponent message={funding.message} guestFunding={guestFunding} />
+                <ButtonWrapper>
+                    <PurpleButton>펀딩 참여하기</PurpleButton>
+                </ButtonWrapper>
             </ContentContainer>
         </AppContainer>
     )
@@ -53,37 +76,10 @@ const FundingDetail = () => {
 
 export default FundingDetail;
 
-const FundingCard = styled.div`
-    display: flex;
-    align-items: center;
-    padding: 13px;
-    background-color: #fff;
-    border-radius: 8px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-`;
-
-const FundingImage = styled.img`
-    width: 100px;
-    height: 100px;
-    object-fit: cover;
-    border-radius: 8px;
-    margin-right: 16px;
-`;
-
-const FundingDetails = styled.div`
-    flex: 1;
-`;
-
-const FundingTitle = styled.div`
-    font-size: 16px;
-    font-weight: bold;
-    font-family: "Pretendard";
-    margin-bottom: 10px;
-`;
-
-const FundingInfo = styled.div`
-    font-size: 12px;
-    font-family: "Pretendard";
-    color: #666;
-    text-align: right;
+const ButtonWrapper = styled.div`
+    padding-top: 0px;
+    padding-bottom: 0px;
+    position: absolute;
+    bottom: 10px;
+    width: calc(100% - 48px);
 `;

--- a/src/pages/funding/FundingDetail.js
+++ b/src/pages/funding/FundingDetail.js
@@ -1,0 +1,89 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import axios from 'axios';
+import styled from 'styled-components';
+import AppContainer from "../../components/AppContainer";
+import NavigationBar from "../../components/Nav/NavigationBar";
+import ContentContainer from "../../components/ContentContainer";
+import BackButtonIcon from '../../assets/images/back-button.png';
+import { TopContainer, BackButton, CenterTitle } from '../../components/Header/Header';
+import FundingCardComponent from '../../components/funding/FundingCardComponent';
+
+const FundingDetail = () => {
+    const navigate = useNavigate();
+
+    const funding = {
+        fundingId: 1,
+        title: '우리의 결혼을 축하해주세요1',
+        message: '여러분의 작은 성원이 큰 기쁨이 됩니다. 많은 참여 부탁드립니다.1',
+        targetAmount: 1940000,
+        currentAmount: 1000,
+        status: 'IN_PROGRESS',
+        endDate: '2024-12-31T23:59:00',
+        participantCount: 1,
+        productOptions: {
+            productOptionsId: 1,
+            mainImages: [
+                { imageId: 1, imageName: '333464cf-168b-4903-9ce2-ccdacd4a1e75.jpg' },
+                { imageId: 2, imageName: 'image2.jpg' }
+            ]
+        },
+        couple: {
+            coupleId: 1,
+            people: [
+                { phoneNumber: '01011111111', weddingRole: 'GROOM', name: '웨딩일' },
+                { phoneNumber: '01022222222', weddingRole: 'BRIDE', name: '웨딩이' }
+            ]
+        }
+    };
+
+    return (
+        <AppContainer>
+            <NavigationBar />
+            <ContentContainer>
+                <TopContainer>
+                <BackButton src={BackButtonIcon} alt="Back" onClick={() => navigate(-1)} />
+                    <CenterTitle>펀딩 상세</CenterTitle>
+                </TopContainer>
+                <FundingCardComponent funding={funding} />
+            </ContentContainer>
+        </AppContainer>
+    )
+}
+
+export default FundingDetail;
+
+const FundingCard = styled.div`
+    display: flex;
+    align-items: center;
+    padding: 13px;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+`;
+
+const FundingImage = styled.img`
+    width: 100px;
+    height: 100px;
+    object-fit: cover;
+    border-radius: 8px;
+    margin-right: 16px;
+`;
+
+const FundingDetails = styled.div`
+    flex: 1;
+`;
+
+const FundingTitle = styled.div`
+    font-size: 16px;
+    font-weight: bold;
+    font-family: "Pretendard";
+    margin-bottom: 10px;
+`;
+
+const FundingInfo = styled.div`
+    font-size: 12px;
+    font-family: "Pretendard";
+    color: #666;
+    text-align: right;
+`;

--- a/src/pages/funding/FundingDetail.js
+++ b/src/pages/funding/FundingDetail.js
@@ -13,48 +13,36 @@ import GuestFundingComponent from '../../components/funding/GuestFundingComponen
 
 const FundingDetail = () => {
     const navigate = useNavigate();
+    const { fundingId } = useParams();
+    const [funding, setFunding] = useState(null);
+    const [guestFunding, setGuestFunding] = useState([]);
 
-    const funding = {
-        fundingId: 1,
-        title: '우리의 결혼을 축하해주세요1',
-        message: '여러분의 작은 성원이 큰 기쁨이 됩니다. 많은 참여 부탁드립니다.1',
-        targetAmount: 1940000,
-        currentAmount: 1000,
-        status: 'IN_PROGRESS',
-        endDate: '2024-12-31T23:59:00',
-        participantCount: 1,
-        productOptions: {
-            productOptionsId: 1,
-            mainImages: [
-                { imageId: 1, imageName: '333464cf-168b-4903-9ce2-ccdacd4a1e75.jpg' },
-                { imageId: 2, imageName: 'image2.jpg' }
-            ]
-        },
-        couple: {
-            coupleId: 1,
-            people: [
-                { phoneNumber: '01011111111', weddingRole: 'GROOM', name: '웨딩일' },
-                { phoneNumber: '01022222222', weddingRole: 'BRIDE', name: '웨딩이' }
-            ]
-        }
-    };
+    useEffect(() => {
+        const fetchFunding = async () => {
+            try {
+                const fundingResponse = await axios.get(`http://localhost:8080/fundings/${fundingId}`);
+                setFunding(fundingResponse.data);
+            } catch (error) {
+                console.error('Error fetching funding:', error);
+            }
+        };
 
-    const guestFunding = [
-        {
-            "guestFundingId": 1,
-            "name": "게스트일",
-            "fundingAmount": 1000,
-            "message": "결혼 축하한다. 행복하게 잘 살렴.",
-            "paidAt": "2024-06-07T02:52:44"
-        },
-        {
-            "guestFundingId": 2,
-            "name": "게스트이",
-            "fundingAmount": 2000,
-            "message": "결혼 축2",
-            "paidAt": "2024-06-07T02:52:54"
-        }
-    ];
+        const fetchGuestFunding = async () => {
+            try {
+                const guestFundingResponse = await axios.get(`http://localhost:8080/fundings/${fundingId}/guest-fundings`);
+                setGuestFunding(guestFundingResponse.data);
+            } catch (error) {
+                console.error('Error fetching guest fundings:', error);
+            }
+        };
+
+        fetchFunding();
+        fetchGuestFunding();
+    }, [fundingId]);
+
+    if (!funding) {
+        return <div>Loading...</div>;
+    }
 
     return (
         <AppContainer>

--- a/src/pages/funding/FundingList.js
+++ b/src/pages/funding/FundingList.js
@@ -1,0 +1,131 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import axios from 'axios';
+import styled from 'styled-components';
+import AppContainer from "../../components/AppContainer";
+import NavigationBar from "../../components/Nav/NavigationBar";
+import ContentContainer from "../../components/ContentContainer";
+import BackButtonIcon from '../../assets/images/back-button.png';
+import { TopContainer, BackButton, CenterTitle } from '../../components/Header/Header';
+
+const FundingListContainer = styled.div`
+`;
+
+const FundingCard = styled.div`
+    display: flex;
+    align-items: center;
+    padding: 13px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    margin-bottom: 16px;
+`;
+
+const FundingImage = styled.img`
+    width: 100px;
+    height: 100px;
+    object-fit: cover;
+    border-radius: 8px;
+    margin-right: 16px;
+`;
+
+const FundingDetails = styled.div`
+    flex: 1;
+`;
+
+const FundingTitle = styled.div`
+    font-size: 16px;
+    font-weight: bold;
+    font-family: "Pretendard";
+    margin-bottom: 5px;
+`;
+
+const FundingInfo = styled.div`
+    font-size: 12px;
+    font-family: "Pretendard";
+    color: #666;
+    text-align: right;
+`;
+
+const FundingProgress = styled.div`
+    margin-top: 8px;
+`;
+
+const ProgressInfo = styled.div`
+    font-size: 12px;
+    font-family: "Pretendard";
+    color: #666;
+`;
+
+const ProgressBar = styled.div`
+    width: 100%;
+    height: 5px;
+    background-color: #ddd;
+    border-radius: 5px;
+    overflow: hidden;
+    margin-top: 4px;
+`;
+
+const Progress = styled.div`
+    width: ${props => props.progress}%;
+    height: 100%;
+    background-color: #4c3073;
+`;
+
+const FundingParticipation = () => {
+    const navigate = useNavigate();
+
+    const fundings = [
+        {
+            id: 1,
+            title: "동은이네 첫 냉장고",
+            participantCount: 12,
+            endDate: "2024-04-27",
+            progress: 50,
+            selectedOption: {
+                mainImages: [{ imageName: "example.jpg" }]
+            }
+        },
+        {
+            id: 2,
+            title: "동은이네 첫 김치 냉장고",
+            participantCount: 1,
+            endDate: "2024-04-27",
+            progress: 5,
+            selectedOption: {
+                mainImages: [{ imageName: "example.jpg" }]
+            }
+        }
+    ];
+
+    return (
+        <AppContainer>
+            <NavigationBar />
+            <ContentContainer>
+                <TopContainer>
+                    <BackButton src={BackButtonIcon} alt="Back" onClick={() => navigate(-1)} />
+                    <CenterTitle>현재 진행 중인 펀딩</CenterTitle>
+                </TopContainer>
+                <FundingListContainer>
+                    {fundings.map((funding) => (
+                        <FundingCard key={funding.id}>
+                            <FundingImage src={`https://via.placeholder.com/100`} alt={funding.title} />
+                            <FundingDetails>
+                                <FundingTitle>{funding.title}</FundingTitle>
+                                <FundingInfo>{funding.participantCount}명 참여</FundingInfo>
+                                <FundingInfo>마감 기한 {new Date(funding.endDate).toLocaleDateString()}</FundingInfo>
+                                <FundingProgress>
+                                    <ProgressInfo>펀딩 진행률 {funding.progress}%</ProgressInfo>
+                                    <ProgressBar>
+                                        <Progress progress={funding.progress} />
+                                    </ProgressBar>
+                                </FundingProgress>
+                            </FundingDetails>
+                        </FundingCard>
+                    ))}
+                </FundingListContainer>
+            </ContentContainer>
+        </AppContainer>
+    );
+}
+
+export default FundingParticipation;

--- a/src/pages/funding/FundingList.js
+++ b/src/pages/funding/FundingList.js
@@ -12,7 +12,7 @@ import FundingCardComponent from '../../components/funding/FundingCardComponent'
 const FundingListContainer = styled.div`
 `;
 
-const FundingParticipation = () => {
+const FundingList = () => {
     const navigate = useNavigate();
     const { coupleId } = useParams(); // coupleId 파라미터를 받아옴
     const [fundings, setFundings] = useState([]);
@@ -30,6 +30,10 @@ const FundingParticipation = () => {
         fetchFundings();
     }, [coupleId]);
 
+    const handleCardClick = (fundingId) => {
+        navigate(`/fundings/${fundingId}`);
+    };
+
     return (
         <AppContainer>
             <NavigationBar />
@@ -40,7 +44,9 @@ const FundingParticipation = () => {
                 </TopContainer>
                 <FundingListContainer>
                     {fundings.map((funding) => (
-                        <FundingCardComponent key={funding.fundingId} funding={funding} />
+                        <div key={funding.fundingId} onClick={() => handleCardClick(funding.fundingId)}>
+                            <FundingCardComponent funding={funding} />
+                        </div>
                     ))}
                 </FundingListContainer>
             </ContentContainer>
@@ -48,4 +54,4 @@ const FundingParticipation = () => {
     );
 }
 
-export default FundingParticipation;
+export default FundingList;

--- a/src/pages/funding/FundingList.js
+++ b/src/pages/funding/FundingList.js
@@ -7,68 +7,9 @@ import NavigationBar from "../../components/Nav/NavigationBar";
 import ContentContainer from "../../components/ContentContainer";
 import BackButtonIcon from '../../assets/images/back-button.png';
 import { TopContainer, BackButton, CenterTitle } from '../../components/Header/Header';
+import FundingCardComponent from '../../components/funding/FundingCardComponent';
 
 const FundingListContainer = styled.div`
-`;
-
-const FundingCard = styled.div`
-    display: flex;
-    align-items: center;
-    padding: 13px;
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    margin-bottom: 16px;
-`;
-
-const FundingImage = styled.img`
-    width: 100px;
-    height: 100px;
-    object-fit: cover;
-    border-radius: 8px;
-    margin-right: 16px;
-`;
-
-const FundingDetails = styled.div`
-    flex: 1;
-`;
-
-const FundingTitle = styled.div`
-    font-size: 16px;
-    font-weight: bold;
-    font-family: "Pretendard";
-    margin-bottom: 10px;
-`;
-
-const FundingInfo = styled.div`
-    font-size: 12px;
-    font-family: "Pretendard";
-    color: #666;
-    text-align: right;
-`;
-
-const FundingProgress = styled.div`
-    margin-top: 8px;
-`;
-
-const ProgressInfo = styled.div`
-    font-size: 12px;
-    font-family: "Pretendard";
-    color: #666;
-`;
-
-const ProgressBar = styled.div`
-    width: 100%;
-    height: 5px;
-    background-color: #ddd;
-    border-radius: 5px;
-    overflow: hidden;
-    margin-top: 4px;
-`;
-
-const Progress = styled.div`
-    width: ${props => props.progress}%;
-    height: 100%;
-    background-color: #4c3073;
 `;
 
 const FundingParticipation = () => {
@@ -98,25 +39,9 @@ const FundingParticipation = () => {
                     <CenterTitle>현재 진행 중인 펀딩</CenterTitle>
                 </TopContainer>
                 <FundingListContainer>
-                    {fundings.map((funding) => {
-                        const progress = (funding.currentAmount / funding.targetAmount) * 100;
-                        return (
-                            <FundingCard key={funding.fundingId}>
-                                <FundingImage src={`https://lovecloud-storage.s3.ap-northeast-2.amazonaws.com/images/${funding.productOptions.mainImages[0].imageName}`} alt={funding.title} />
-                                <FundingDetails>
-                                    <FundingTitle>{funding.title}</FundingTitle>
-                                    <FundingInfo>{funding.participantCount}명 참여</FundingInfo>
-                                    <FundingInfo>마감 기한 {new Date(funding.endDate).toLocaleDateString()}</FundingInfo>
-                                    <FundingProgress>
-                                        <ProgressInfo>펀딩 진행률 {progress.toFixed(2)}%</ProgressInfo>
-                                        <ProgressBar>
-                                            <Progress progress={progress} />
-                                        </ProgressBar>
-                                    </FundingProgress>
-                                </FundingDetails>
-                            </FundingCard>
-                        );
-                    })}
+                    {fundings.map((funding) => (
+                        <FundingCardComponent key={funding.fundingId} funding={funding} />
+                    ))}
                 </FundingListContainer>
             </ContentContainer>
         </AppContainer>

--- a/src/pages/funding/FundingList.js
+++ b/src/pages/funding/FundingList.js
@@ -36,7 +36,7 @@ const FundingTitle = styled.div`
     font-size: 16px;
     font-weight: bold;
     font-family: "Pretendard";
-    margin-bottom: 5px;
+    margin-bottom: 10px;
 `;
 
 const FundingInfo = styled.div`
@@ -73,29 +73,21 @@ const Progress = styled.div`
 
 const FundingParticipation = () => {
     const navigate = useNavigate();
+    const { coupleId } = useParams(); // coupleId 파라미터를 받아옴
+    const [fundings, setFundings] = useState([]);
 
-    const fundings = [
-        {
-            id: 1,
-            title: "동은이네 첫 냉장고",
-            participantCount: 12,
-            endDate: "2024-04-27",
-            progress: 50,
-            selectedOption: {
-                mainImages: [{ imageName: "example.jpg" }]
+    useEffect(() => {
+        const fetchFundings = async () => {
+            try {
+                const response = await axios.get(`http://localhost:8080/couples/${coupleId}/fundings`);
+                setFundings(response.data);
+            } catch (error) {
+                console.error('Error fetching fundings:', error);
             }
-        },
-        {
-            id: 2,
-            title: "동은이네 첫 김치 냉장고",
-            participantCount: 1,
-            endDate: "2024-04-27",
-            progress: 5,
-            selectedOption: {
-                mainImages: [{ imageName: "example.jpg" }]
-            }
-        }
-    ];
+        };
+
+        fetchFundings();
+    }, [coupleId]);
 
     return (
         <AppContainer>
@@ -106,22 +98,25 @@ const FundingParticipation = () => {
                     <CenterTitle>현재 진행 중인 펀딩</CenterTitle>
                 </TopContainer>
                 <FundingListContainer>
-                    {fundings.map((funding) => (
-                        <FundingCard key={funding.id}>
-                            <FundingImage src={`https://via.placeholder.com/100`} alt={funding.title} />
-                            <FundingDetails>
-                                <FundingTitle>{funding.title}</FundingTitle>
-                                <FundingInfo>{funding.participantCount}명 참여</FundingInfo>
-                                <FundingInfo>마감 기한 {new Date(funding.endDate).toLocaleDateString()}</FundingInfo>
-                                <FundingProgress>
-                                    <ProgressInfo>펀딩 진행률 {funding.progress}%</ProgressInfo>
-                                    <ProgressBar>
-                                        <Progress progress={funding.progress} />
-                                    </ProgressBar>
-                                </FundingProgress>
-                            </FundingDetails>
-                        </FundingCard>
-                    ))}
+                    {fundings.map((funding) => {
+                        const progress = (funding.currentAmount / funding.targetAmount) * 100;
+                        return (
+                            <FundingCard key={funding.fundingId}>
+                                <FundingImage src={`https://lovecloud-storage.s3.ap-northeast-2.amazonaws.com/images/${funding.productOptions.mainImages[0].imageName}`} alt={funding.title} />
+                                <FundingDetails>
+                                    <FundingTitle>{funding.title}</FundingTitle>
+                                    <FundingInfo>{funding.participantCount}명 참여</FundingInfo>
+                                    <FundingInfo>마감 기한 {new Date(funding.endDate).toLocaleDateString()}</FundingInfo>
+                                    <FundingProgress>
+                                        <ProgressInfo>펀딩 진행률 {progress.toFixed(2)}%</ProgressInfo>
+                                        <ProgressBar>
+                                            <Progress progress={progress} />
+                                        </ProgressBar>
+                                    </FundingProgress>
+                                </FundingDetails>
+                            </FundingCard>
+                        );
+                    })}
                 </FundingListContainer>
             </ContentContainer>
         </AppContainer>


### PR DESCRIPTION
## 📌 관련 이슈

closed #27 

## 💗 작업 동기

신혼부부/하객이 펀딩 상세 내용을 보고, 하객이 펀딩에 참여할 수 있는 페이지가 필요합니다.

## 🛠️ 작업 내용
- [x] 펀딩 상세 페이지 구현
- [x] 펀딩 목록 페이지에서 특정 펀딩 클릭 시 해당 펀딩 상세 페이지로 이동 
- [x] 펀딩 생성 페이지 FundingParticipation -> FundingCreate로 이름 수정

## 🎯 리뷰 포인트

잘 동작하는지 봐주세요~

## ✅ 테스트 결과

![image](https://github.com/yu-LoveCloud/love-cloud-client/assets/96174711/660c7e7d-c7c7-48f2-ad04-59073c3ccc92)

