### PR TITLE
feat: 펀딩 참여 페이지 구현

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -10,6 +10,7 @@ import ProductDetail from "./pages/product/ProductDetail";
 import FundingCreate from './pages/funding/FundingCreate';
 import FundingList from './pages/funding/FundingList';
 import FundingDetail from './pages/funding/FundingDetail';
+import FundingParticipate from './pages/funding/FundingParticipate';
 
 function Router() {
   return (
@@ -31,6 +32,7 @@ function Router() {
       <Route path="/funding/create/:productOptionsId" element={<FundingCreate />} />
       <Route path="/couples/:coupleId/fundings" element={<FundingList />} />
       <Route path="/fundings/:fundingId" element={<FundingDetail />} />
+      <Route path="/fundings/:fundingId/participate" element={<FundingParticipate />} />
     </Routes>
   );
 }

--- a/src/components/Common.js
+++ b/src/components/Common.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export const Divider = styled.div`
+    height: 0.5px;
+    background-color: #D9D9D9;
+    margin: 30px 0;
+`;

--- a/src/components/Typography.js
+++ b/src/components/Typography.js
@@ -77,3 +77,10 @@ export const TextArea = styled(Input).attrs({ as: "textarea" })`
   resize: none; /* 크기 조절 비활성화 */
   padding: 12px; /* padding 추가 */
 `;
+
+export const SectionTitle = styled.div`
+  font-size: 16px;
+  font-weight: bold;
+  font-family: "Pretendard";
+  margin: 20px 0 20px;
+`;

--- a/src/components/funding/FundingParticipationFormComponent.js
+++ b/src/components/funding/FundingParticipationFormComponent.js
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { OrderedListContainer, ListItem, Input, TextArea } from "../../components/Typography";
+
+const FundingParticipationForm = () => {
+    const [name, setName] = useState('');
+    const [phone, setPhone] = useState('');
+    const [email, setEmail] = useState('');
+    const [fundingAmount, setFundingAmount] = useState('');
+    const [message, setMessage] = useState('');
+
+    const handleAmountButtonClick = (amount) => {
+        setFundingAmount(prevAmount => formatNumber(Number(prevAmount.replace(/,/g, '')) + amount));
+    };
+
+    const handleFundingAmountChange = (e) => {
+        const value = e.target.value.replace(/,/g, ''); // 기존 쉼표 제거
+        if (!isNaN(value) && value.trim() !== '') {
+            setFundingAmount(formatNumber(value));
+        } else {
+            setFundingAmount('');
+        }
+    };
+
+    const formatNumber = (value) => {
+        return Number(value).toLocaleString();
+    };
+
+    return (
+        <FormContainer>
+            <OrderedListContainer>
+                <ListItem>이름</ListItem>
+                <Input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="이름을 입력해주세요"
+                />
+                <ListItem>휴대폰 번호</ListItem>
+                <Input
+                    type="text"
+                    value={phone}
+                    onChange={(e) => setPhone(e.target.value)}
+                    placeholder="휴대폰 번호를 입력해주세요"
+                />
+                <ListItem>이메일</ListItem>
+                <Input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="이메일을 입력해주세요"
+                />
+                <ListItem>펀딩 금액 입력</ListItem>
+                <InputWrapper>
+                    <StyledInput
+                        type="text"
+                        value={fundingAmount}
+                        onChange={handleFundingAmountChange}
+                        placeholder="펀딩 금액을 입력해주세요"
+                    />
+                    <AmountText>원</AmountText>
+                </InputWrapper>
+                <ButtonGroup>
+                    <AmountButton onClick={() => handleAmountButtonClick(300000)}>+ 30만</AmountButton>
+                    <AmountButton onClick={() => handleAmountButtonClick(100000)}>+ 10만</AmountButton>
+                    <AmountButton onClick={() => handleAmountButtonClick(50000)}>+ 5만</AmountButton>
+                    <AmountButton onClick={() => handleAmountButtonClick(10000)}>+ 1만</AmountButton>
+                </ButtonGroup>
+                <ListItem>응원 메시지</ListItem>
+                <TextArea
+                    value={message}
+                    onChange={(e) => setMessage(e.target.value)}
+                    placeholder="응원 메시지를 입력해주세요"
+                />
+            </OrderedListContainer>
+        </FormContainer>
+    );
+};
+
+export default FundingParticipationForm;
+
+const FormContainer = styled.div`
+    margin-bottom: 40px;
+`;
+
+const InputWrapper = styled.div`
+    position: relative;
+    display: flex;
+    align-items: center;
+`;
+
+const StyledInput = styled(Input)`
+    padding-right: 30px; /* 오른쪽에 여백 추가 */
+`;
+
+const AmountText = styled.span`
+    position: absolute;
+    right: 10px;
+    font-family: "Pretendard";
+    font-size: 14px;
+    color: #767676;
+    margin-bottom: 15px;
+`;
+
+const ButtonGroup = styled.div`
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 15px;
+`;
+
+const AmountButton = styled.button`
+    padding: 10px 20px;
+    background-color: #D9D9D9;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    font-family: "Pretendard";
+    color: #767676;
+    font-size: 12px;
+`;

--- a/src/components/funding/FundingParticipationFormComponent.js
+++ b/src/components/funding/FundingParticipationFormComponent.js
@@ -2,19 +2,14 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { OrderedListContainer, ListItem, Input, TextArea } from "../../components/Typography";
 
-const FundingParticipationForm = () => {
-    const [name, setName] = useState('');
-    const [phone, setPhone] = useState('');
-    const [email, setEmail] = useState('');
-    const [fundingAmount, setFundingAmount] = useState('');
-    const [message, setMessage] = useState('');
+const FundingParticipationForm = ({ setName, setPhone, setEmail, setFundingAmount, setMessage, name, phone, email, fundingAmount, message }) => {
 
     const handleAmountButtonClick = (amount) => {
         setFundingAmount(prevAmount => formatNumber(Number(prevAmount.replace(/,/g, '')) + amount));
     };
 
     const handleFundingAmountChange = (e) => {
-        const value = e.target.value.replace(/,/g, ''); // 기존 쉼표 제거
+        const value = e.target.value.replace(/,/g, '');
         if (!isNaN(value) && value.trim() !== '') {
             setFundingAmount(formatNumber(value));
         } else {
@@ -22,8 +17,21 @@ const FundingParticipationForm = () => {
         }
     };
 
+    const handlePhoneChange = (e) => {
+        const value = e.target.value.replace(/-/g, '');
+        if (!isNaN(value)) {
+            setPhone(formatPhoneNumber(value));
+        }
+    };
+
     const formatNumber = (value) => {
         return Number(value).toLocaleString();
+    };
+
+    const formatPhoneNumber = (value) => {
+        if (value.length <= 3) return value;
+        if (value.length <= 7) return `${value.slice(0, 3)}-${value.slice(3)}`;
+        return `${value.slice(0, 3)}-${value.slice(3, 7)}-${value.slice(7)}`;
     };
 
     return (
@@ -39,7 +47,7 @@ const FundingParticipationForm = () => {
                 <Input
                     type="text"
                     value={phone}
-                    onChange={(e) => setPhone(e.target.value)}
+                    onChange={handlePhoneChange}
                     placeholder="휴대폰 번호를 입력해주세요"
                 />
                 <ListItem>이메일</ListItem>
@@ -89,16 +97,17 @@ const InputWrapper = styled.div`
 `;
 
 const StyledInput = styled(Input)`
-    padding-right: 30px; /* 오른쪽에 여백 추가 */
+    padding-right: 30px;
 `;
 
 const AmountText = styled.span`
     position: absolute;
     right: 10px;
+    top: 30%;
+    transform: translateY(-50%);
     font-family: "Pretendard";
     font-size: 14px;
     color: #767676;
-    margin-bottom: 15px;
 `;
 
 const ButtonGroup = styled.div`

--- a/src/components/funding/RecipientCardComponent.js
+++ b/src/components/funding/RecipientCardComponent.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const RecipientCardComponent = ({ people }) => {
+    
+    const formatPhoneNumber = (phoneNumber) => {
+        return phoneNumber.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
+    };
+
+    return (
+        <RecipientCard>
+            <Person>
+                <RecipientRole>신부</RecipientRole>
+                <RecipientInfo>
+                    <div>{people.find(person => person.weddingRole === 'BRIDE').name}</div>
+                    <div>{formatPhoneNumber(people.find(person => person.weddingRole === 'BRIDE').phoneNumber)}</div>
+                </RecipientInfo>
+            </Person>
+            <Divider />
+            <Person>
+                <RecipientRole>신랑</RecipientRole>
+                <RecipientInfo>
+                    <div>{people.find(person => person.weddingRole === 'GROOM').name}</div>
+                    <div>{formatPhoneNumber(people.find(person => person.weddingRole === 'GROOM').phoneNumber)}</div>
+                </RecipientInfo>
+            </Person>
+        </RecipientCard>
+    );
+};
+
+export default RecipientCardComponent;
+
+const RecipientCard = styled.div`
+    padding: 3px 20px;
+    background-color: #D9D9D9;
+    border-radius: 12px;
+`;
+
+const Person = styled.div`
+    display: flex;
+    justify-content: space-between;
+    padding: 10px 0;
+`;
+
+const RecipientRole = styled.div`
+    font-family: "Pretendard";
+    font-size: 14px;
+    color: #767676;
+`;
+
+const RecipientInfo = styled.div`
+    text-align: right;
+    font-size: 14px;
+    font-family: "Pretendard";
+    margin-top: 15px;
+    & > div {
+        margin-bottom: 3px;
+    }
+`;
+
+const Divider = styled.div`
+    height: 1px;
+    background-color: #767676;
+    margin: 5px 0;
+`;

--- a/src/pages/funding/FundingDetail.js
+++ b/src/pages/funding/FundingDetail.js
@@ -49,13 +49,13 @@ const FundingDetail = () => {
             <NavigationBar />
             <ContentContainer>
                 <TopContainer>
-                <BackButton src={BackButtonIcon} alt="Back" onClick={() => navigate(-1)} />
+                    <BackButton src={BackButtonIcon} alt="Back" onClick={() => navigate(-1)} />
                     <CenterTitle>펀딩 상세</CenterTitle>
                 </TopContainer>
                 <FundingCardComponent funding={funding} />
                 <GuestFundingComponent message={funding.message} guestFunding={guestFunding} />
                 <ButtonWrapper>
-                    <PurpleButton>펀딩 참여하기</PurpleButton>
+                    <PurpleButton onClick={() => navigate(`/fundings/${fundingId}/participate`)}>펀딩 참여하기</PurpleButton>
                 </ButtonWrapper>
             </ContentContainer>
         </AppContainer>

--- a/src/pages/funding/FundingParticipate.js
+++ b/src/pages/funding/FundingParticipate.js
@@ -1,0 +1,90 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import axios from 'axios';
+import styled from 'styled-components';
+import AppContainer from "../../components/AppContainer";
+import NavigationBar from "../../components/Nav/NavigationBar";
+import ContentContainer from "../../components/ContentContainer";
+import BackButtonIcon from '../../assets/images/back-button.png';
+import PurpleButton from "../../components/button/PurpleButton";
+import { TopContainer, BackButton, CenterTitle } from '../../components/Header/Header';
+import { SectionTitle } from "../../components/Typography";
+import FundingCardComponent from '../../components/funding/FundingCardComponent';
+import RecipientCardComponent from '../../components/funding/RecipientCardComponent';
+import FundingParticipationForm from '../../components/funding/FundingParticipationFormComponent';
+import { Divider } from '../../components/Common';
+
+const FundingParticipate = () => {
+    const navigate = useNavigate();
+    
+    const funding = {
+        fundingId: 1,
+        title: "우리의 결혼을 축하해주세요1",
+        message: "여러분의 작은 성원이 큰 기쁨이 됩니다. 많은 참여 부탁드립니다.1",
+        targetAmount: 1940000,
+        currentAmount: 1000,
+        status: "IN_PROGRESS",
+        endDate: "2024-12-31T23:59:00",
+        participantCount: 1,
+        productOptions: {
+            productOptionsId: 1,
+            mainImages: [
+                {
+                    imageId: 1,
+                    imageName: "333464cf-168b-4903-9ce2-ccdacd4a1e75.jpg"
+                },
+                {
+                    imageId: 2,
+                    imageName: "image2.jpg"
+                }
+            ]
+        },
+        couple: {
+            coupleId: 1,
+            people: [
+                {
+                    phoneNumber: "01011111111",
+                    weddingRole: "GROOM",
+                    name: "웨딩일"
+                },
+                {
+                    phoneNumber: "01022222222",
+                    weddingRole: "BRIDE",
+                    name: "웨딩이"
+                }
+            ]
+        }
+    };
+
+    return (
+        <AppContainer>
+            <NavigationBar />
+            <ContentContainer>
+                <TopContainer>
+                    <BackButton src={BackButtonIcon} alt="Back" onClick={() => navigate(-1)} />
+                    <CenterTitle>펀딩 참여</CenterTitle>
+                </TopContainer>
+                <FundingCardComponent funding={funding} />
+                <Divider />
+                <SectionTitle>받으시는 분</SectionTitle>
+                <RecipientCardComponent people={funding.couple.people} />
+                <Divider />
+                <SectionTitle>보내시는 분</SectionTitle>
+                <FundingParticipationForm />
+                <ButtonWrapper>
+                    <PurpleButton>결제하기</PurpleButton>
+                </ButtonWrapper>
+            </ContentContainer>
+        </AppContainer>
+    )
+}
+
+export default FundingParticipate;
+
+const ButtonWrapper = styled.div`
+    padding-top: 0px;
+    padding-bottom: 0px;
+    position: absolute;
+    bottom: 10px;
+    width: calc(100% - 48px);
+`;

--- a/src/pages/funding/FundingParticipate.js
+++ b/src/pages/funding/FundingParticipate.js
@@ -16,46 +16,24 @@ import { Divider } from '../../components/Common';
 
 const FundingParticipate = () => {
     const navigate = useNavigate();
+    const { fundingId } = useParams();
+    const [funding, setFunding] = useState(null);
     
-    const funding = {
-        fundingId: 1,
-        title: "우리의 결혼을 축하해주세요1",
-        message: "여러분의 작은 성원이 큰 기쁨이 됩니다. 많은 참여 부탁드립니다.1",
-        targetAmount: 1940000,
-        currentAmount: 1000,
-        status: "IN_PROGRESS",
-        endDate: "2024-12-31T23:59:00",
-        participantCount: 1,
-        productOptions: {
-            productOptionsId: 1,
-            mainImages: [
-                {
-                    imageId: 1,
-                    imageName: "333464cf-168b-4903-9ce2-ccdacd4a1e75.jpg"
-                },
-                {
-                    imageId: 2,
-                    imageName: "image2.jpg"
-                }
-            ]
-        },
-        couple: {
-            coupleId: 1,
-            people: [
-                {
-                    phoneNumber: "01011111111",
-                    weddingRole: "GROOM",
-                    name: "웨딩일"
-                },
-                {
-                    phoneNumber: "01022222222",
-                    weddingRole: "BRIDE",
-                    name: "웨딩이"
-                }
-            ]
-        }
-    };
+    useEffect(() => {
+        const fetchFundingData = async () => {
+            try {
+                const response = await axios.get(`http://localhost:8080/fundings/${fundingId}`);
+                setFunding(response.data);
+            } catch (error) {
+                console.error('Error fetching funding data:', error);
+            }
+        };
 
+        fetchFundingData();
+    }, [fundingId]);
+
+    if (!funding) return <div>Loading...</div>;
+    
     return (
         <AppContainer>
             <NavigationBar />

--- a/src/pages/funding/FundingParticipate.js
+++ b/src/pages/funding/FundingParticipate.js
@@ -18,7 +18,13 @@ const FundingParticipate = () => {
     const navigate = useNavigate();
     const { fundingId } = useParams();
     const [funding, setFunding] = useState(null);
-    
+
+    const [name, setName] = useState('');
+    const [phone, setPhone] = useState('');
+    const [email, setEmail] = useState('');
+    const [fundingAmount, setFundingAmount] = useState('');
+    const [message, setMessage] = useState('');
+
     useEffect(() => {
         const fetchFundingData = async () => {
             try {
@@ -32,8 +38,22 @@ const FundingParticipate = () => {
         fetchFundingData();
     }, [fundingId]);
 
+    const handleSubmit = () => {
+        const plainPhone = phone.replace(/-/g, '');
+        const plainFundingAmount = fundingAmount.replace(/,/g, '');
+
+        const data = {
+            name,
+            phone: plainPhone,
+            email,
+            fundingAmount: plainFundingAmount,
+            message,
+        };
+        console.log('Submitted data:', data);
+    };
+
     if (!funding) return <div>Loading...</div>;
-    
+
     return (
         <AppContainer>
             <NavigationBar />
@@ -48,13 +68,24 @@ const FundingParticipate = () => {
                 <RecipientCardComponent people={funding.couple.people} />
                 <Divider />
                 <SectionTitle>보내시는 분</SectionTitle>
-                <FundingParticipationForm />
+                <FundingParticipationForm
+                    setName={setName}
+                    setPhone={setPhone}
+                    setEmail={setEmail}
+                    setFundingAmount={setFundingAmount}
+                    setMessage={setMessage}
+                    name={name}
+                    phone={phone}
+                    email={email}
+                    fundingAmount={fundingAmount}
+                    message={message}
+                />
                 <ButtonWrapper>
-                    <PurpleButton>결제하기</PurpleButton>
+                    <PurpleButton onClick={handleSubmit}>결제하기</PurpleButton>
                 </ButtonWrapper>
             </ContentContainer>
         </AppContainer>
-    )
+    );
 }
 
 export default FundingParticipate;


### PR DESCRIPTION
## 📌 관련 이슈

closed #34 

## 💗 작업 동기

하객이 펀딩 상세 페이지에서 펀딩 참여 버튼을 누른 후,
펀딩 참여를 위한 정보를 입력하고 참여 버튼을 눌러, 결제를 걸쳐 주문을 완료하는 기능이 필요합니다.

## 🛠️ 작업 내용

- [x] 펀딩 참여 페이지 구현
- [x] 펀딩 참여 과정에 따른 각각의 API 요청[펀딩 참여 과정](https://github.com/yu-LoveCloud/love-cloud-was/pull/75)

## 🎯 리뷰 포인트

계속 주문 완료 단계에서 400 에러 떠는데, 백엔드에는 로그 찍히는 게 없어서
이것저것 삽질하다가 결제 완료 Response가 json 형태가 아니라 단순히 id를 넘겨준다는 걸 깨달았다는 사실 ..

paymentResponse.data.paymentId가 아니라 paymentResponse.data 자체가 paymentId였네요

## ✅ 테스트 결과
- API 연동 후이고, 화면 구성을 아래와 같고
![image](https://github.com/yu-LoveCloud/love-cloud-client/assets/96174711/3bf4f9f0-2fd9-46f6-9b1e-159ca22b712a)

![image](https://github.com/yu-LoveCloud/love-cloud-client/assets/96174711/1dedd78a-5fc3-4e40-b755-0517a8ef50cc)

- 주문 요청 -> 결제 요청 -> 결제 완료 -> 주문 완료까지 잘 됩니다 ~
![image](https://github.com/yu-LoveCloud/love-cloud-client/assets/96174711/a1e98239-58e0-43b3-a84a-4d3398a4834e)

