### PR TITLE
feat: API호출시 헤더에 액세스토큰 설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.7.2",
         "react": "^18.3.1",
+        "react-cookie": "^7.1.4",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
@@ -4066,6 +4067,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
@@ -4117,6 +4123,15 @@
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
       }
     },
     "node_modules/@types/html-minifier-terser": {
@@ -9306,6 +9321,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -15022,6 +15050,19 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
+    "node_modules/react-cookie": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-7.1.4.tgz",
+      "integrity": "sha512-wDxxa/HYaSXSMlyWJvJ5uZTzIVtQTPf1gMksFgwAz/2/W3lCtY8r4OChCXMPE7wax0PAdMY97UkNJedGv7KnDw==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.5",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^7.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -17517,6 +17558,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.1.4.tgz",
+      "integrity": "sha512-Q+DVJsdykStWRMtXr2Pdj3EF98qZHUH/fXv/gwFz/unyToy1Ek1w5GsWt53Pf38tT8Gbcy5QNsj61Xe9TggP4g==",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.6.0"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.7.2",
     "react": "^18.3.1",
+    "react-cookie": "^7.1.4",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",

--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { BASE_URL } from "../constants/global";
+import { getCookie, setCookie, removeCookie } from "../Cookie";
 
 export const apiClient = axios.create({
   baseURL: BASE_URL,
@@ -7,3 +8,65 @@ export const apiClient = axios.create({
     "Content-Type": "application/json",
   },
 });
+
+// 요청 인터셉터 추가. 액세스토큰을 요청 헤더에 추가함
+apiClient.interceptors.request.use(
+  (config) => {
+    const accessToken = getCookie("access_token");
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+// 응답 인터셉터 추가
+apiClient.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+    const originalRequest = error.config;
+
+    // 401 에러 및 만료된 액세스 토큰일 경우
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        const refreshToken = getCookie("refresh_token");
+        if (!refreshToken) {
+          throw new Error("No refresh token available");
+        }
+
+        const response = await axios.post(
+          `${BASE_URL}/auth/refresh-token`,
+          {},
+          {
+            headers: {
+              Authorization: `Bearer ${refreshToken}`,
+            },
+          }
+        );
+
+        const newAccessToken = response.data.accessToken;
+        const newRefreshToken = response.data.refreshToken;
+
+        setCookie("access_token", newAccessToken, { path: "/" });
+        setCookie("refresh_token", newRefreshToken, { path: "/" });
+
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return axios(originalRequest);
+      } catch (tokenRefreshError) {
+        console.error("Failed to refresh token", tokenRefreshError);
+        removeCookie("access_token");
+        removeCookie("refresh_token");
+
+        return Promise.reject(tokenRefreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);

--- a/src/api/fundingApi.js
+++ b/src/api/fundingApi.js
@@ -10,3 +10,13 @@ export const getFundingList = async () => {
     throw error;
   }
 };
+
+export const getOrderableFundingList = async () => {
+  try {
+    const response = await apiClient.get("/orderable-fundings");
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching orderable funding list:", error);
+    throw error;
+  }
+};

--- a/src/pages/product/ProductList.js
+++ b/src/pages/product/ProductList.js
@@ -1,251 +1,325 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
-import axios from 'axios';
+import React, { useState, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import axios from "axios";
 import AppContainer from "../../components/AppContainer";
 import NavigationBar from "../../components/Nav/NavigationBar";
 import ContentContainer from "../../components/ContentContainer";
 import { Title } from "../../components/Typography";
-import SelectedHeart from '../../assets/images/product/selected-heart.png';
-import UnselectedHeart from '../../assets/images/product/unselected-heart.png';
+import SelectedHeart from "../../assets/images/product/selected-heart.png";
+import UnselectedHeart from "../../assets/images/product/unselected-heart.png";
+import { apiClient } from "../../api/apiClient";
 
 // styled-components 정의
 const FilterContainer = styled.div`
-    display: flex; // 수평 정렬을 위해 flexbox 사용
-    gap: 10px; // 요소 사이의 간격을 10px로 설정
-    margin-bottom: 20px; // 아래 여백을 20px로 설정
-    overflow-x: auto; // 가로 스크롤 가능하게 설정
-    overflow-y: hidden; // 세로 스크롤은 비활성화
-    white-space: nowrap; // 줄바꿈을 하지 않도록 설정
-    cursor: grab; // 드래그 가능 상태 커서로 설정
-    user-select: none; // 텍스트 선택을 비활성화
-    scrollbar-width: none; // Firefox에서 스크롤바 숨기기
-    &::-webkit-scrollbar {
-        display: none; // Chrome, Safari에서 스크롤바 숨기기
-    }
+  display: flex; // 수평 정렬을 위해 flexbox 사용
+  gap: 10px; // 요소 사이의 간격을 10px로 설정
+  margin-bottom: 20px; // 아래 여백을 20px로 설정
+  overflow-x: auto; // 가로 스크롤 가능하게 설정
+  overflow-y: hidden; // 세로 스크롤은 비활성화
+  white-space: nowrap; // 줄바꿈을 하지 않도록 설정
+  cursor: grab; // 드래그 가능 상태 커서로 설정
+  user-select: none; // 텍스트 선택을 비활성화
+  scrollbar-width: none; // Firefox에서 스크롤바 숨기기
+  &::-webkit-scrollbar {
+    display: none; // Chrome, Safari에서 스크롤바 숨기기
+  }
 `;
 
 const FilterButton = styled.button`
-    padding: 10px 20px; // 내부 여백 설정
-    border: 1px solid #ccc; // 테두리 설정
-    background-color: ${props => (props.active ? '#4c3073' : '#fff')}; // 활성 상태에 따라 배경색 변경
-    color: ${props => (props.active ? '#fff' : '#000')}; // 활성 상태에 따라 글자색 변경
-    border-radius: 20px; // 모서리를 둥글게 설정
-    cursor: pointer; // 클릭 가능한 커서로 설정
-    font-size: 14px; // 글자 크기 설정
-    font-family: "Pretendard"; // 글꼴 설정
+  padding: 10px 20px; // 내부 여백 설정
+  border: 1px solid #ccc; // 테두리 설정
+  background-color: ${(props) =>
+    props.active ? "#4c3073" : "#fff"}; // 활성 상태에 따라 배경색 변경
+  color: ${(props) =>
+    props.active ? "#fff" : "#000"}; // 활성 상태에 따라 글자색 변경
+  border-radius: 20px; // 모서리를 둥글게 설정
+  cursor: pointer; // 클릭 가능한 커서로 설정
+  font-size: 14px; // 글자 크기 설정
+  font-family: "Pretendard"; // 글꼴 설정
 `;
 
 const SortSelectContainer = styled.div`
-    display: flex;
-    justify-content: flex-end; // 오른쪽 정렬
-    margin-bottom: 20px; // 아래 여백을 20px로 설정
+  display: flex;
+  justify-content: flex-end; // 오른쪽 정렬
+  margin-bottom: 20px; // 아래 여백을 20px로 설정
 `;
 
 const SortSelect = styled.select`
-    padding: 10px 20px; // 내부 여백 설정
-    background-color: #fff; // 배경색 설정
-    color: #000; // 글자색 설정
-    border: none; // 테두리 없음으로 설정
-    border-radius: 20px; // 모서리를 둥글게 설정
-    cursor: pointer; // 클릭 가능한 커서로 설정
-    font-size: 14px; // 글자 크기 설정
-    font-family: "Pretendard"; // 글꼴 설정
+  padding: 10px 20px; // 내부 여백 설정
+  background-color: #fff; // 배경색 설정
+  color: #000; // 글자색 설정
+  border: none; // 테두리 없음으로 설정
+  border-radius: 20px; // 모서리를 둥글게 설정
+  cursor: pointer; // 클릭 가능한 커서로 설정
+  font-size: 14px; // 글자 크기 설정
+  font-family: "Pretendard"; // 글꼴 설정
 `;
 
 const ProductGrid = styled.div`
-    display: flex; // 수평 정렬을 위해 flexbox 사용
-    flex-wrap: wrap; // 요소들이 줄바꿈 되도록 설정
-    gap: 20px; // 요소 사이의 간격을 20px로 설정
+  display: flex; // 수평 정렬을 위해 flexbox 사용
+  flex-wrap: wrap; // 요소들이 줄바꿈 되도록 설정
+  gap: 20px; // 요소 사이의 간격을 20px로 설정
 `;
 
 const ProductCard = styled.div`
-    flex: 1 1 calc(50% - 20px); // 카드의 너비를 50%로 설정하고, 간격을 고려하여 조정
-    max-width: calc(50% - 20px); // 최대 너비를 50%로 설정
-    border: 1px solid #ccc; // 테두리 설정
-    border-radius: 10px; // 모서리를 둥글게 설정
-    overflow: hidden; // 내용이 넘칠 경우 숨기기
-    text-align: center; // 텍스트 가운데 정렬
-    background: #fff; // 배경색을 흰색으로 설정
-    position: relative; // 찜 버튼 위치 설정을 위한 상대 위치
+  flex: 1 1 calc(50% - 20px); // 카드의 너비를 50%로 설정하고, 간격을 고려하여 조정
+  max-width: calc(50% - 20px); // 최대 너비를 50%로 설정
+  border: 1px solid #ccc; // 테두리 설정
+  border-radius: 10px; // 모서리를 둥글게 설정
+  overflow: hidden; // 내용이 넘칠 경우 숨기기
+  text-align: center; // 텍스트 가운데 정렬
+  background: #fff; // 배경색을 흰색으로 설정
+  position: relative; // 찜 버튼 위치 설정을 위한 상대 위치
 `;
 
 const ProductImage = styled.img`
-    width: 100%; // 이미지 너비를 100%로 설정
-    height: 200px; // 이미지 높이를 200px로 설정
-    object-fit: cover; // 이미지가 컨테이너에 맞게 조정되도록 설정
+  width: 100%; // 이미지 너비를 100%로 설정
+  height: 200px; // 이미지 높이를 200px로 설정
+  object-fit: cover; // 이미지가 컨테이너에 맞게 조정되도록 설정
 `;
 
 const WishlistButton = styled.button`
-    position: absolute; // 절대 위치 설정
-    top: 10px; // 상단에서 10px 떨어짐
-    right: 10px; // 오른쪽에서 10px 떨어짐
-    background: none; // 배경 없음
-    border: none; // 테두리 없음
-    cursor: pointer; // 클릭 가능한 커서로 설정
-    img {
-        width: 24px; // 이미지 너비 설정
-        height: 24px; // 이미지 높이 설정
-    }
+  position: absolute; // 절대 위치 설정
+  top: 10px; // 상단에서 10px 떨어짐
+  right: 10px; // 오른쪽에서 10px 떨어짐
+  background: none; // 배경 없음
+  border: none; // 테두리 없음
+  cursor: pointer; // 클릭 가능한 커서로 설정
+  img {
+    width: 24px; // 이미지 너비 설정
+    height: 24px; // 이미지 높이 설정
+  }
 `;
 
 const ColorOptions = styled.div`
-    display: flex; // 수평 정렬을 위해 flexbox 사용
-    justify-content: center; // 가운데 정렬
-    gap: 5px; // 요소 사이의 간격을 5px로 설정
-    margin-top: 10px; // 상단 여백을 10px로 설정
-    overflow-x: auto; // 가로 스크롤 가능하게 설정
-    overflow-y: hidden; // 세로 스크롤은 비활성화
-    white-space: nowrap; // 줄바꿈을 하지 않도록 설정
-    cursor: grab; // 드래그 가능 상태 커서로 설정
-    user-select: none; // 텍스트 선택을 비활성화
-    scrollbar-width: none; // Firefox에서 스크롤바 숨기기
-    &::-webkit-scrollbar {
-        display: none; // Chrome, Safari에서 스크롤바 숨기기
-    }
+  display: flex; // 수평 정렬을 위해 flexbox 사용
+  justify-content: center; // 가운데 정렬
+  gap: 5px; // 요소 사이의 간격을 5px로 설정
+  margin-top: 10px; // 상단 여백을 10px로 설정
+  overflow-x: auto; // 가로 스크롤 가능하게 설정
+  overflow-y: hidden; // 세로 스크롤은 비활성화
+  white-space: nowrap; // 줄바꿈을 하지 않도록 설정
+  cursor: grab; // 드래그 가능 상태 커서로 설정
+  user-select: none; // 텍스트 선택을 비활성화
+  scrollbar-width: none; // Firefox에서 스크롤바 숨기기
+  &::-webkit-scrollbar {
+    display: none; // Chrome, Safari에서 스크롤바 숨기기
+  }
 `;
 
 const ColorOptionButton = styled.button`
-    width: 12px; // 버튼 너비 설정
-    height: 12px; // 버튼 높이 설정
-    border-radius: 50%; // 버튼을 원형으로 설정
-    border: ${props => props.isSelected ? '1px solid #000' : '1px solid #ccc'}; // 선택된 경우 검은 테두리, 그렇지 않으면 회색 테두리
-    background-color: ${props => props.color}; // 버튼 배경색 설정
-    cursor: pointer; // 클릭 가능한 커서로 설정
+  width: 12px; // 버튼 너비 설정
+  height: 12px; // 버튼 높이 설정
+  border-radius: 50%; // 버튼을 원형으로 설정
+  border: ${(props) =>
+    props.isSelected
+      ? "1px solid #000"
+      : "1px solid #ccc"}; // 선택된 경우 검은 테두리, 그렇지 않으면 회색 테두리
+  background-color: ${(props) => props.color}; // 버튼 배경색 설정
+  cursor: pointer; // 클릭 가능한 커서로 설정
 `;
 
 const ProductInfo = styled.div`
-    padding: 10px; // 내부 여백 설정
+  padding: 10px; // 내부 여백 설정
 `;
 
 const ProductName = styled.h3`
-    font-size: 14px; // 글자 크기 설정
-    font-family: "Pretendard"; // 글꼴 설정
-    color: #000; // 글자색 설정
+  font-size: 14px; // 글자 크기 설정
+  font-family: "Pretendard"; // 글꼴 설정
+  color: #000; // 글자색 설정
 `;
 
 const ModelName = styled.p`
-    font-size: 11px; // 글자 크기 설정
-    color: #767676; // 글자색 설정
-    font-family: "Pretendard"; // 글꼴 설정
+  font-size: 11px; // 글자 크기 설정
+  color: #767676; // 글자색 설정
+  font-family: "Pretendard"; // 글꼴 설정
 `;
 
 const ProductPrice = styled.p`
-    color: #b49ad9; // 글자색 설정
-    font-size: 14px; // 글자 크기 설정
-    font-family: "Pretendard"; // 글꼴 설정
+  color: #b49ad9; // 글자색 설정
+  font-size: 14px; // 글자 크기 설정
+  font-family: "Pretendard"; // 글꼴 설정
 `;
 
 const ProductList = () => {
-    const [products, setProducts] = useState([]); // 제품 목록 상태 선언
-    const [categories, setCategories] = useState([]); // 카테고리 목록 상태 선언
-    const [selectedCategory, setSelectedCategory] = useState(null); // 선택된 카테고리 상태 선언
-    const [sortOrder, setSortOrder] = useState('등록일순'); // 정렬 순서 상태 선언
-    const [selectedColors, setSelectedColors] = useState({}); // 선택된 색상 상태 선언
-    const navigate = useNavigate(); // useNavigate 훅 선언
+  const [products, setProducts] = useState([]); // 제품 목록 상태 선언
+  const [categories, setCategories] = useState([]); // 카테고리 목록 상태 선언
+  const [selectedCategory, setSelectedCategory] = useState(null); // 선택된 카테고리 상태 선언
+  const [sortOrder, setSortOrder] = useState("등록일순"); // 정렬 순서 상태 선언
+  const [selectedColors, setSelectedColors] = useState({}); // 선택된 색상 상태 선언
+  const navigate = useNavigate(); // useNavigate 훅 선언
 
-    useEffect(() => {
-        const fetchCategories = async () => { // 카테고리를 가져오는 함수 선언
-            try {
-                const response = await axios.get('http://localhost:8080/categories'); // API 요청하여 카테고리 데이터 가져오기
-                setCategories(response.data); // 카테고리 상태 업데이트
-            } catch (error) {
-                console.error('카테고리 가져올 때 에러 발생:', error); // 에러 발생 시 콘솔에 에러 메시지 출력
-            }
-        };
-        fetchCategories(); // 컴포넌트가 마운트될 때 카테고리를 가져오는 함수 호출
-    }, []); // 의존성 배열이 비어있어 컴포넌트 마운트 시 한 번만 실행
-
-    useEffect(() => {
-        const fetchProducts = async () => { // 제품을 가져오는 함수 선언
-            try {
-                const endpoint = selectedCategory ?
-                    `http://localhost:8080/products?categoryId=${selectedCategory}` :
-                    'http://localhost:8080/products'; // 선택된 카테고리에 따라 엔드포인트 설정
-                const response = await axios.get(endpoint); // API 요청하여 제품 데이터 가져오기
-                setProducts(response.data.filter(product => product)); // 제품 상태 업데이트, null 값 필터링
-            } catch (error) {
-                console.error('Error fetching products:', error); // 에러 발생 시 콘솔에 에러 메시지 출력
-            }
-        };
-        fetchProducts(); // 선택된 카테고리가 변경될 때마다 제품을 가져오는 함수 호출
-    }, [selectedCategory]); // 의존성 배열에 selectedCategory 포함하여 선택된 카테고리 변경 시마다 실행
-
-    const handleCategoryChange = (categoryId) => { // 카테고리 변경 핸들러 함수
-        setSelectedCategory(categoryId); // 선택된 카테고리 상태 업데이트
+  useEffect(() => {
+    const fetchCategories = async () => {
+      // 카테고리를 가져오는 함수 선언
+      try {
+        const response = await apiClient.get(
+          "http://localhost:8080/categories"
+        ); // API 요청하여 카테고리 데이터 가져오기
+        setCategories(response.data); // 카테고리 상태 업데이트
+      } catch (error) {
+        console.error("카테고리 가져올 때 에러 발생:", error); // 에러 발생 시 콘솔에 에러 메시지 출력
+      }
     };
+    fetchCategories(); // 컴포넌트가 마운트될 때 카테고리를 가져오는 함수 호출
+  }, []); // 의존성 배열이 비어있어 컴포넌트 마운트 시 한 번만 실행
 
-    const handleSortOrderChange = (event) => { // 정렬 순서 변경 핸들러 함수
-        setSortOrder(event.target.value); // 정렬 순서 상태 업데이트
+  useEffect(() => {
+    const fetchProducts = async () => {
+      // 제품을 가져오는 함수 선언
+      try {
+        const endpoint = selectedCategory
+          ? `http://localhost:8080/products?categoryId=${selectedCategory}`
+          : "http://localhost:8080/products"; // 선택된 카테고리에 따라 엔드포인트 설정
+        const response = await apiClient.get(endpoint); // API 요청하여 제품 데이터 가져오기
+        setProducts(response.data.filter((product) => product)); // 제품 상태 업데이트, null 값 필터링
+      } catch (error) {
+        console.error("Error fetching products:", error); // 에러 발생 시 콘솔에 에러 메시지 출력
+      }
     };
+    fetchProducts(); // 선택된 카테고리가 변경될 때마다 제품을 가져오는 함수 호출
+  }, [selectedCategory]); // 의존성 배열에 selectedCategory 포함하여 선택된 카테고리 변경 시마다 실행
 
-    const handleColorChange = (productId, optionId) => { // 색상 변경 핸들러 함수
-        setSelectedColors(prev => ({
-            ...prev,
-            [productId]: optionId // 선택된 색상 상태 업데이트
-        }));
-    };
+  const handleCategoryChange = (categoryId) => {
+    // 카테고리 변경 핸들러 함수
+    setSelectedCategory(categoryId); // 선택된 카테고리 상태 업데이트
+  };
 
-    const handleProductClick = (productId, selectedOptionId) => { // 상품 클릭 핸들러 함수
-        navigate(`/items/${selectedOptionId}`); // 상세 페이지로 이동
-    };
+  const handleSortOrderChange = (event) => {
+    // 정렬 순서 변경 핸들러 함수
+    setSortOrder(event.target.value); // 정렬 순서 상태 업데이트
+  };
 
-    // 선택된 카테고리 이름 가져오기
-    const selectedCategoryName = selectedCategory
-        ? categories.find(category => category.categoryId === selectedCategory)?.categoryName
-        : '전체';
+  const handleColorChange = (productId, optionId) => {
+    // 색상 변경 핸들러 함수
+    setSelectedColors((prev) => ({
+      ...prev,
+      [productId]: optionId, // 선택된 색상 상태 업데이트
+    }));
+  };
 
-    return (
-        <AppContainer> {/* 전체 앱 컨테이너 */}
-            <NavigationBar /> {/* 네비게이션 바 */}
-            <ContentContainer> {/* 내용 컨테이너 */}
-                <Title>{selectedCategoryName} 제품 목록</Title> {/* 선택된 카테고리 이름 표시 */}
-                <FilterContainer> {/* 필터 버튼 컨테이너 */}
-                    <FilterButton onClick={() => handleCategoryChange(null)} active={!selectedCategory}>
-                        전체
-                    </FilterButton>
-                    {categories.map(category => ( // 카테고리 필터 버튼 반복 렌더링
-                        <FilterButton key={category.categoryId} onClick={() => handleCategoryChange(category.categoryId)} active={selectedCategory === category.categoryId}>
-                            {category.categoryName}
-                        </FilterButton>
-                    ))}
-                </FilterContainer>
-                <SortSelectContainer> {/* 정렬 선택 컨테이너 */}
-                    <SortSelect value={sortOrder} onChange={handleSortOrderChange}>
-                        <option value="등록일순">등록일순</option> {/* 등록일순 옵션 */}
-                    </SortSelect>
-                </SortSelectContainer>
-                <ProductGrid> {/* 제품 그리드 */}
-                    {products.map(product => { // 제품 목록 반복 렌더링
-                        const selectedOptionId = selectedColors[product.productId] || product.options[0].productOptionsId; // 선택된 옵션 ID
-                        const selectedOption = product.options.find(option => option.productOptionsId === selectedOptionId); // 선택된 옵션 객체
+  const handleProductClick = (productId, selectedOptionId) => {
+    // 상품 클릭 핸들러 함수
+    navigate(`/items/${selectedOptionId}`); // 상세 페이지로 이동
+  };
 
-                        return (
-                            <ProductCard key={product.productId} onClick={() => handleProductClick(product.productId, selectedOptionId)}> {/* 제품 카드 */}
-                                <ProductImage src={`https://lovecloud-storage.s3.ap-northeast-2.amazonaws.com/images/${selectedOption.mainImages[0].imageName}`} alt={product.productName} /> {/* 제품 이미지 */}
-                                {/* <WishlistButton onClick={() => toggleWishlist(product.productId)}> */}
-                                {/*     <img src={product.isWishlisted ? SelectedHeart : UnselectedHeart} alt="찜" /> */}
-                                {/* </WishlistButton> */}
-                                <ProductInfo> {/* 제품 정보 */}
-                                    <ColorOptions> {/* 색상 옵션 */}
-                                        {product.options.map(option => ( // 색상 옵션 반복 렌더링
-                                            <ColorOptionButton key={option.productOptionsId} color={option.color} isSelected={option.productOptionsId === selectedOptionId} onClick={(e) => {
-                                                e.stopPropagation(); // 부모 요소로의 클릭 이벤트 전파 중단
-                                                handleColorChange(product.productId, option.productOptionsId); // 색상 변경 처리
-                                            }} />
-                                        ))}
-                                    </ColorOptions>
-                                    <ProductName>{product.productName}</ProductName> {/* 제품 이름 */}
-                                    <ModelName>{selectedOption.modelName}</ModelName> {/* 모델 이름 */}
-                                    <ProductPrice>{`₩${selectedOption.price.toLocaleString()}`}</ProductPrice> {/* 제품 가격 */}
-                                </ProductInfo>
-                            </ProductCard>
-                        );
-                    })}
-                </ProductGrid>
-            </ContentContainer>
-        </AppContainer>
-    );
+  // 선택된 카테고리 이름 가져오기
+  const selectedCategoryName = selectedCategory
+    ? categories.find((category) => category.categoryId === selectedCategory)
+        ?.categoryName
+    : "전체";
+
+  return (
+    <AppContainer>
+      {" "}
+      {/* 전체 앱 컨테이너 */}
+      <NavigationBar /> {/* 네비게이션 바 */}
+      <ContentContainer>
+        {" "}
+        {/* 내용 컨테이너 */}
+        <Title>{selectedCategoryName} 제품 목록</Title>{" "}
+        {/* 선택된 카테고리 이름 표시 */}
+        <FilterContainer>
+          {" "}
+          {/* 필터 버튼 컨테이너 */}
+          <FilterButton
+            onClick={() => handleCategoryChange(null)}
+            active={!selectedCategory}
+          >
+            전체
+          </FilterButton>
+          {categories.map(
+            (
+              category // 카테고리 필터 버튼 반복 렌더링
+            ) => (
+              <FilterButton
+                key={category.categoryId}
+                onClick={() => handleCategoryChange(category.categoryId)}
+                active={selectedCategory === category.categoryId}
+              >
+                {category.categoryName}
+              </FilterButton>
+            )
+          )}
+        </FilterContainer>
+        <SortSelectContainer>
+          {" "}
+          {/* 정렬 선택 컨테이너 */}
+          <SortSelect value={sortOrder} onChange={handleSortOrderChange}>
+            <option value="등록일순">등록일순</option> {/* 등록일순 옵션 */}
+          </SortSelect>
+        </SortSelectContainer>
+        <ProductGrid>
+          {" "}
+          {/* 제품 그리드 */}
+          {products.map((product) => {
+            // 제품 목록 반복 렌더링
+            const selectedOptionId =
+              selectedColors[product.productId] ||
+              product.options[0].productOptionsId; // 선택된 옵션 ID
+            const selectedOption = product.options.find(
+              (option) => option.productOptionsId === selectedOptionId
+            ); // 선택된 옵션 객체
+
+            return (
+              <ProductCard
+                key={product.productId}
+                onClick={() =>
+                  handleProductClick(product.productId, selectedOptionId)
+                }
+              >
+                {" "}
+                {/* 제품 카드 */}
+                <ProductImage
+                  src={`https://lovecloud-storage.s3.ap-northeast-2.amazonaws.com/images/${selectedOption.mainImages[0].imageName}`}
+                  alt={product.productName}
+                />{" "}
+                {/* 제품 이미지 */}
+                {/* <WishlistButton onClick={() => toggleWishlist(product.productId)}> */}
+                {/*     <img src={product.isWishlisted ? SelectedHeart : UnselectedHeart} alt="찜" /> */}
+                {/* </WishlistButton> */}
+                <ProductInfo>
+                  {" "}
+                  {/* 제품 정보 */}
+                  <ColorOptions>
+                    {" "}
+                    {/* 색상 옵션 */}
+                    {product.options.map(
+                      (
+                        option // 색상 옵션 반복 렌더링
+                      ) => (
+                        <ColorOptionButton
+                          key={option.productOptionsId}
+                          color={option.color}
+                          isSelected={
+                            option.productOptionsId === selectedOptionId
+                          }
+                          onClick={(e) => {
+                            e.stopPropagation(); // 부모 요소로의 클릭 이벤트 전파 중단
+                            handleColorChange(
+                              product.productId,
+                              option.productOptionsId
+                            ); // 색상 변경 처리
+                          }}
+                        />
+                      )
+                    )}
+                  </ColorOptions>
+                  <ProductName>{product.productName}</ProductName>{" "}
+                  {/* 제품 이름 */}
+                  <ModelName>{selectedOption.modelName}</ModelName>{" "}
+                  {/* 모델 이름 */}
+                  <ProductPrice>{`₩${selectedOption.price.toLocaleString()}`}</ProductPrice>{" "}
+                  {/* 제품 가격 */}
+                </ProductInfo>
+              </ProductCard>
+            );
+          })}
+        </ProductGrid>
+      </ContentContainer>
+    </AppContainer>
+  );
 };
 
 export default ProductList;


### PR DESCRIPTION
## 📌 관련 이슈

closed #38 

## 💗 작업 동기
API호출시 헤더에 액세스토큰을 설정해야한다.

## 🛠️ 작업 내용

PR에서 작업한 주요 내용을 적어주세요.

- [x] 인터셉터를 통해 fetch 요청 전에 헤더에 access_token을 설정
- [x] 인터셉트를 통해 응답시 status==401 (만료됨) 인 경우 토큰을 재발급

## 🎯 리뷰 포인트

인터셉트를 통해 요청시 헤더에 access_token을 삽입,
응답시 status===401(만료됨)인 경우 토큰을 재발급받아 쿠키에 저장하고, 시도하던 api를 다시 호출함

그런데 인터셉트가 작동되는것은 제가 작성해놓은 apiClient를 통해 호출할때만 적용되기 때문에
기존에 `await axios.get(endpoint)` 처럼 작성하셨던 코드를 `await apiClient.get(endpoint)` 로 수정해주셔야합니다. (apiClient는 src/api/apiClient.js 에 정의되어있음)

- 리뷰 포인트

## ✅ 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷를 첨부할 수 있어요.
<img width="425" alt="image" src="https://github.com/yu-LoveCloud/love-cloud-client/assets/101257697/7bd60f07-ad67-4f3c-9f7e-0d495e71961e">

(토큰 이용)주문정보가 잘 받아와지는것을 확인